### PR TITLE
Joblib with loky instead of multiprocessing.

### DIFF
--- a/book/mle/contour_loglik_stochvol.py
+++ b/book/mle/contour_loglik_stochvol.py
@@ -3,7 +3,7 @@
 
 """
 Plot the contours of the log-likelihood of a stochastic volatility model;
-see Figure 13.1 in the MLE Chapter for more details.
+see Figure 14.1 in the MLE Chapter for more details.
 
 Notes: this script uses multi-processing to speed things up; this may not work
 on certain OSes (see documentation). Replace 0 by 1 in line 41 below to discard

--- a/particles/utils.py
+++ b/particles/utils.py
@@ -72,9 +72,9 @@ from __future__ import division, print_function
 
 import functools
 import itertools
-import multiprocessing
 import time
 
+import joblib
 import numpy as np
 from numpy import random
 
@@ -163,26 +163,20 @@ def distribute_work(f, inputs, outputs=None, nprocs=1, out_key='output'):
     if outputs is None:
         outputs = [ip.copy() for ip in inputs]
     if nprocs <= 0:
-        nprocs += multiprocessing.cpu_count()
+        nprocs += joblib.cpu_count()
 
     # no multiprocessing
     if nprocs <= 1:
         return [add_to_dict(op, f(**ip), key=out_key)
                 for ip, op in zip(inputs, outputs)]
 
+    delayed_f = joblib.delayed(f)
+
     # multiprocessing
-    queue_in = multiprocessing.Queue()
-    queue_out = multiprocessing.Queue()
-    procs = [multiprocessing.Process(target=worker,
-                                     args=(queue_in, queue_out, f))
-             for _ in range(nprocs)]
-    sent = [queue_in.put((i, args)) for i, args in enumerate(inputs)]
-    [queue_in.put((None, None)) for _ in range(nprocs)] # signalling the end of queue
-    [p.start() for p in procs]
-    results = [queue_out.get() for _ in sent]
-    for i, r in results:
+    pool = joblib.Parallel(n_jobs=nprocs, backend="loky")  # this backend is very
+    results = pool(delayed_f(**ip) for ip in inputs)
+    for i, r in enumerate(results):
         add_to_dict(outputs[i], r)
-    [p.join() for p in procs]
 
     return outputs
 
@@ -269,4 +263,3 @@ def multiplexer(f=None, nruns=1, nprocs=1, seeding=None, protected_args=None,
             op['seed'] = seed
     # the actual work happens here
     return distribute_work(f, inputs, outputs, nprocs=nprocs)
-

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+joblib==1.0.1
 numba
 numpy
 scipy


### PR DESCRIPTION
Tested on Ubuntu for functionality break. It's fine.
Also the random seeding behaviour of joblib is easier to understand than the multiprocessing one. So it may also have fixed the recurring "scipy frozen distributions don't work" problem, but this needs to be tested.

I will test on Windows before converting from draft PR.