### PR TITLE
fixed simulation bug where integer distributions threw an error

### DIFF
--- a/particles/distributions.py
+++ b/particles/distributions.py
@@ -840,7 +840,7 @@ class MixMissing(ProbDist):
         return lp
 
     def rvs(self, size=None):
-        x = self.base_dist.rvs(size=size)
+        x = self.base_dist.rvs(size=size).astype(float)
         N = x.shape[0]
         is_missing = random.rand(N) < self.pmiss
         x[is_missing, ...] = np.nan


### PR DESCRIPTION
For ssm.StateSpaceModel, when using fk.simulate from a state space model fk that had a partially missing MixMissing variable, NaN threw an error if I employed an integer valued distribution.

Small change: force dists.MixMissing to a float, which can handle NaN. 