### PR TITLE
change default loc param to vector

### DIFF
--- a/particles/distributions.py
+++ b/particles/distributions.py
@@ -891,7 +891,7 @@ class MvNormal(ProbDist):
     Parameters
     ----------
     loc: ndarray
-        location parameter (default: 0.)
+        location parameter (default: np.array([0.]))
     scale: ndarray
         scale parameter (default: 1.)
     cov: (d, d) ndarray
@@ -928,7 +928,7 @@ class MvNormal(ProbDist):
     matrix for each particle, see `VaryingCovNormal`.
     """
 
-    def __init__(self, loc=0.0, scale=1.0, cov=None):
+    def __init__(self, loc=np.array([0.0]), scale=1.0, cov=None):
         self.loc = loc
         self.scale = scale
         self.cov = np.eye(loc.shape[-1]) if cov is None else cov


### PR DESCRIPTION
loc parameter of MvNormal was 0.0 (float). Changing to np.array([0.0]) should solve issue #97