### PR TITLE
fix typos in distributions.py

### DIFF
--- a/docs/source/notebooks/Bayes_estimation_ssm.ipynb
+++ b/docs/source/notebooks/Bayes_estimation_ssm.ipynb
@@ -444,7 +444,7 @@
     "Again, a few choices are made for you by default: \n",
     "\n",
     "* A bootstrap filter is run for each $\\theta-$particle; this may be changed by setting option `fk_class` while instantiating `SMC2`; e.g. ``fk_class=ssm.GuidedPF`` will run instead a guided filter. \n",
-    "* Option `init_Nx` determines the **initial** number of $x-$particles; the algorithm automatically increases $N_x$ each time the acceptance rate drops below $10\%$ (as specified through option ``ar_to_increase=0.1``. Set this this option to `0.` if you do not want to increase $N_x$ in the course of t he algorithm.\n",
+    "* Option `init_Nx` determines the **initial** number of $x-$particles; the algorithm automatically increases $N_x$ each time the acceptance rate drops below $10%$ (as specified through option ``ar_to_increase=0.1``. Set this this option to `0.` if you do not want to increase $N_x$ in the course of t he algorithm.\n",
     "* The particle filters (in the $x-$dimension) are run with the default options of class `SMC`; e.g. resampling is set to `systematic` and so on; other options may be set by using option `smc_options`."
    ]
   },

--- a/docs/source/notebooks/Bayes_estimation_ssm.ipynb
+++ b/docs/source/notebooks/Bayes_estimation_ssm.ipynb
@@ -307,7 +307,7 @@
     "  * the starting point of the chain is sampled from the prior; you may instead set it to a specific value using option `starting_point` (when instantiating `PMMH`); \n",
     "  * the proposal is an **adaptative** Gaussian random walk: this means that the covariance matrix of the random step is calibrated on the fly on past simulations (using vanishing adaptation). This may be disabled by setting option `adaptive=False`; \n",
     "  * a bootstrap filter is run to approximate the log-likelihood; you may use a different filter (e.g. a guided filter) by passing a `FeynmanKac` class to option `fk_cls`;\n",
-    "  * you may also want to pass various parameters to each call to ` SMC` through (dict) argument `smc_options`; e.g. `smc_options={'qmc': True}` will make each particle filter a SQMC algorithm. \n",
+    "  * you may also want to pass various parameters to each call to `SMC` through (dict) argument `smc_options`; e.g. `smc_options={'qmc': True}` will make each particle filter a SQMC algorithm. \n",
     "  \n",
     "Thus, by and large, quite a lot of flexibility is hidden behind this default behaviour."
    ]
@@ -444,7 +444,7 @@
     "Again, a few choices are made for you by default: \n",
     "\n",
     "* A bootstrap filter is run for each $\\theta-$particle; this may be changed by setting option `fk_class` while instantiating `SMC2`; e.g. ``fk_class=ssm.GuidedPF`` will run instead a guided filter. \n",
-    "* Option `init_Nx` determines the **initial** number of $x-$particles; the algorithm automatically increases $N_x$ each time the acceptance rate drops below $10%$ (as specified through option ``ar_to_increase=0.1``. Set this this option to `0.` if you do not want to increase $N_x$ in the course of t he algorithm.\n",
+    "* Option `init_Nx` determines the **initial** number of $x-$particles; the algorithm automatically increases $N_x$ each time the acceptance rate drops below $10\\%$ (as specified through option ``ar_to_increase=0.1``. Set this this option to `0.` if you do not want to increase $N_x$ in the course of t he algorithm.\n",
     "* The particle filters (in the $x-$dimension) are run with the default options of class `SMC`; e.g. resampling is set to `systematic` and so on; other options may be set by using option `smc_options`."
    ]
   },
@@ -473,7 +473,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -487,9 +487,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/docs/source/notebooks/Bayes_estimation_ssm.ipynb
+++ b/docs/source/notebooks/Bayes_estimation_ssm.ipynb
@@ -444,7 +444,7 @@
     "Again, a few choices are made for you by default: \n",
     "\n",
     "* A bootstrap filter is run for each $\\theta-$particle; this may be changed by setting option `fk_class` while instantiating `SMC2`; e.g. ``fk_class=ssm.GuidedPF`` will run instead a guided filter. \n",
-    "* Option `init_Nx` determines the **initial** number of $x-$particles; the algorithm automatically increases $N_x$ each time the acceptance rate drops below $10%$ (as specified through option ``ar_to_increase=0.1``. Set this this option to `0.` if you do not want to increase $N_x$ in the course of t he algorithm.\n",
+    "* Option `init_Nx` determines the **initial** number of $x-$particles; the algorithm automatically increases $N_x$ each time the acceptance rate drops below $10\%$ (as specified through option ``ar_to_increase=0.1``. Set this this option to `0.` if you do not want to increase $N_x$ in the course of t he algorithm.\n",
     "* The particle filters (in the $x-$dimension) are run with the default options of class `SMC`; e.g. resampling is set to `systematic` and so on; other options may be set by using option `smc_options`."
    ]
   },

--- a/particles/distributions.py
+++ b/particles/distributions.py
@@ -30,8 +30,8 @@ Logistic(loc=0., scale=1.)
 LogNormal(mu=0., sigma=1.)               Dist of Y=e^X, X ~ N(μ, σ^2)
 Normal(loc=0., scale=1.)                 N(loc,scale^2) distribution
 Student(loc=0., scale=1., df=3)
-TruncNormal(mu=0, sigma=1., a=0., b=1.)  N(mu, sigma^2) truncated to intervalp [a,b]
-Uniform(a=0., b=1.)                      uniform over intervalp [a,b]
+TruncNormal(mu=0, sigma=1., a=0., b=1.)  N(mu, sigma^2) truncated to interval [a,b]
+Uniform(a=0., b=1.)                      uniform over interval [a,b]
 =======================================  =====================
 
 and the following classes of univariate discrete distributions:
@@ -179,10 +179,10 @@ Here is a list of distributions implementing posteriors:
 Distribution    Corresponding model  comments
 ============    =================== ==================
 Normal          N(theta, sigma^2),   sigma fixed (passed as extra argument)
-TruncNormalp     same
+TruncNormal     same
 Gamma           N(0, 1/theta)
 InvGamma        N(0, theta)
-MvNormalp        N(theta, Sigma)     Sigma fixed (passed as extra argument)
+MvNormal        N(theta, Sigma)     Sigma fixed (passed as extra argument)
 ============    =================== ==================
 
 
@@ -195,7 +195,7 @@ or `DiscreteDist`, for a discrete distribution. This willp properly set class
 attributes ``dim`` (the dimension, set to one, for a univariate distribution),
 and ``dtype``, so that they play nicely with `StructDist` and so on. You will
 also have to properly define methods ``rvs``, ``logpdf`` and ``ppf``. You may
-omit ``ppf`` if you do not plan to use SQMC (Sequentialp quasi Monte Carlo).
+omit ``ppf`` if you do not plan to use SQMC (Sequential quasi Monte Carlo).
 
 
 """
@@ -566,7 +566,7 @@ class Geometric(DiscreteDist):
 
 
 class NegativeBinomial(DiscreteDist):
-    """Negative Binomialp distribution.
+    """Negative Binomial distribution.
 
     Parameters
     ----------
@@ -756,7 +756,7 @@ class LogitD(TransformedDist):
     base_dist: ProbDist
         The distribution of X
     a, b: float
-        intervalp [a, b] is the support of base_dist
+        interval [a, b] is the support of base_dist
 
     """
 
@@ -1128,12 +1128,12 @@ def IID(law, k):
 
 
 class Cond(ProbDist):
-    """Conditionalp distributions.
+    """Conditional distributions.
 
-    A conditionalp distribution acts as a function, which takes as input the
+    A conditional distribution acts as a function, which takes as input the
     current value of the samples, and returns a probability distribution.
 
-    This is used to specify conditionalp distributions in `StructDist`; see the
+    This is used to specify conditional distributions in `StructDist`; see the
     documentation of that class for more details.
     """
 
@@ -1174,13 +1174,14 @@ class StructDist(ProbDist):
         # means mu~N(0,1), tau|mu ~ N(mu,1)
 
     In the third line, ``Cond`` is a ``ProbDist`` class that represents
-    a conditionalp distribution; it is initialized with a function that
+    a conditional distribution; it is initialized with a function that
     returns for each ``x`` a distribution that may depend on fields in ``x``.
 
     Parameters
     ----------
     laws: dict or ordered dict (as explained above)
         keys are parameter names, values are `ProbDist` objects
+    
 
     """
 


### PR DESCRIPTION
there probably was some "al" -> "alp" replacement in the past which created a few typos